### PR TITLE
Error handling fix

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -297,7 +297,7 @@ extern "C" {
     }
 
     void Config_clearColorSpaces(Config* p) {
-        BEGIN_CATCH_ERR
+        BEGIN_CATCH_CTX_ERR(p)
         ocigo::g_Config_map.get(p->handle).get()->clearColorSpaces();
         END_CATCH_CTX_ERR(p)
     }

--- a/context.cpp
+++ b/context.cpp
@@ -25,10 +25,11 @@ extern "C" {
 
     ContextId Context_Create() {
         OCIO::ContextRcPtr ptr;
-        BEGIN_CATCH_ERR
-        ptr = OCIO::Context::Create();
-        END_CATCH_ERR
-        return NEW_HANDLE_CONTEXT(ocigo::g_Context_map.add(ptr));
+        ContextId ctx = NEW_HANDLE_CONTEXT();
+        BEGIN_CATCH_CTX_ERR(ctx)
+        ctx->handle = ocigo::g_Context_map.add(OCIO::Context::Create());
+        END_CATCH_CTX_ERR(ctx)
+        return ctx;
     }
 
     ContextId Context_createEditableCopy(ContextId p) {

--- a/context.go
+++ b/context.go
@@ -38,11 +38,11 @@ func NewContext() *Context {
 	return newContext(C.Context_Create())
 }
 
-func (c *Context) lastError() error {
+func (c *Context) lastError(errno ...error) error {
 	if c == nil {
 		return nil
 	}
-	err := getLastError(c.ptr)
+	err := getLastError(c.ptr, errno...)
 	runtime.KeepAlive(c)
 	return err
 }
@@ -62,8 +62,8 @@ func (c *Context) EditableCopy() *Context {
 }
 
 func (c *Context) CacheID() (string, error) {
-	id := C.Context_getCacheID(c.ptr)
-	if err := c.lastError(); err != nil {
+	id, err := C.Context_getCacheID(c.ptr)
+	if err = c.lastError(err); err != nil {
 		return "", err
 	}
 	runtime.KeepAlive(c)
@@ -148,8 +148,8 @@ func (c *Context) ResolveStringVar(val string) string {
 func (c *Context) ResolveFileLocation(filename string) (string, error) {
 	c_name := C.CString(filename)
 	defer C.free(unsafe.Pointer(c_name))
-	val := C.Context_resolveFileLocation(c.ptr, c_name)
-	if err := c.lastError(); err != nil {
+	val, err := C.Context_resolveFileLocation(c.ptr, c_name)
+	if err = c.lastError(err); err != nil {
 		return "", err
 	}
 	runtime.KeepAlive(c)

--- a/ocio.cpp
+++ b/ocio.cpp
@@ -16,6 +16,7 @@ _HandleContext* NEW_HANDLE_CONTEXT(HandleId handle) {
     _HandleContext *ctx = new _HandleContext;
     ctx->handle = handle;
     ctx->last_error = NULL;
+    ctx->has_error = false;
     return ctx;
 }
 
@@ -46,6 +47,10 @@ extern "C" {
             free_last_ctx_err(ctx);
             delete ctx;
         }
+    }
+
+    bool hasLastError(_HandleContext* ctx) {
+        return ctx->has_error;
     }
 
     const char* getLastError(_HandleContext* ctx) {
@@ -87,11 +92,5 @@ extern "C" {
         OCIO::SetLoggingLevel((OCIO::LoggingLevel)level); 
         END_CATCH_ERR
     };
-
-    // const char* GetLastError() {
-    //     (void) pthread_once(&last_err_once, make_last_err);
-    //     char *err= (char*) pthread_getspecific(last_err);
-    //     return err;
-    // }
 
 }

--- a/ocio.go
+++ b/ocio.go
@@ -67,6 +67,9 @@ func getLastError(ptr *C._HandleContext) error {
 	if ptr == nil {
 		return nil
 	}
+	if !bool(C.hasLastError(ptr)) {
+		return nil
+	}
 	err := C.getLastError(ptr)
 	if err == nil {
 		return nil

--- a/ocio.h
+++ b/ocio.h
@@ -72,6 +72,7 @@ typedef uint64_t HandleId;
 typedef struct _HandleContext {
     HandleId handle;
     const char* last_error;
+    bool has_error;
 } _HandleContext;
 
 // typedef void Config;
@@ -86,6 +87,7 @@ typedef HandleId TransformId;
 typedef HandleId DisplayTransformId;
 
 void freeHandleContext(_HandleContext* ctx);
+bool hasLastError(_HandleContext* ctx);
 const char* getLastError(_HandleContext* ctx);
 
 // Global

--- a/ocio_abi.h
+++ b/ocio_abi.h
@@ -52,6 +52,7 @@ Prefer defining types as a _HandleContext and using BEGIN_CATCH_CTX_ERR(ctx)
 
 
 #define END_CATCH_ERR                        \
+        errno = 0;                           \
     }                                        \
     catch (const OCIO::Exception& ex) {      \
         errno = ERR_GENERAL;                 \
@@ -74,6 +75,7 @@ _HandleContext and stored in maps (Config, Context, Processor).
 
 
 #define END_CATCH_CTX_ERR(CTX)               \
+        errno = 0;                           \
     }                                        \
     catch (const OCIO::Exception& ex) {      \
         free_last_ctx_err(CTX);              \

--- a/ocio_test.go
+++ b/ocio_test.go
@@ -518,17 +518,19 @@ func TestConfigProcessor(t *testing.T) {
 
 	_, err = cfg.Processor("scene_linear", "color_timing")
 	if err != nil {
-		t.Fatal("Error getting a Processor with 'scene_linear', 'color_timing'")
+		t.Fatalf("Error getting a Processor with 'scene_linear', 'color_timing': %v", err)
 	}
 
 	_, err = cfg.Processor(ROLE_COMPOSITING_LOG, ROLE_SCENE_LINEAR)
 	if err != nil {
-		t.Fatal("Error getting a Processor with constants ROLE_COMPOSITING_LOG, ROLE_SCENE_LINEAR")
+		t.Fatalf("Error getting a Processor with constants "+
+			"ROLE_COMPOSITING_LOG, ROLE_SCENE_LINEAR: %v", err)
 	}
 
 	_, err = cfg.Processor(ct, ROLE_COMPOSITING_LOG, ROLE_SCENE_LINEAR)
 	if err != nil {
-		t.Fatal("Error getting a Processor with current context and constants ROLE_COMPOSITING_LOG, ROLE_SCENE_LINEAR")
+		t.Fatalf("Error getting a Processor with current context "+
+			"and constants ROLE_COMPOSITING_LOG, ROLE_SCENE_LINEAR: %v", err)
 	}
 
 	// From data

--- a/ocio_test.go
+++ b/ocio_test.go
@@ -158,6 +158,16 @@ func TestConfigFromFile(t *testing.T) {
 
 	t.Logf("Config read from temp file %s (%v)", fname, c)
 	c.Destroy()
+
+	_, err = ConfigCreateFromFile("/path/to/missing/ocio/file.ocio")
+	if err == nil {
+		t.Fatal("expected missing config file path to return error; got nil")
+	}
+	actual := err.Error()
+	substr := "Error could not read '/path/to/missing/ocio/file.ocio' OCIO profile"
+	if !strings.Contains(actual, substr) {
+		t.Fatalf("expected error %q to contain %q", actual, substr)
+	}
 }
 
 func TestConfigFromData(t *testing.T) {
@@ -166,6 +176,16 @@ func TestConfigFromData(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	t.Logf("Config: %+v", c)
+
+	_, err = ConfigCreateFromData("_bad_config_data_")
+	if err == nil {
+		t.Fatal("expected bad config data to return an error; got nil")
+	}
+	actual := err.Error()
+	substr := "Error: Loading the OCIO profile"
+	if !strings.Contains(actual, substr) {
+		t.Fatalf("expected error %q to contain %q", actual, substr)
+	}
 }
 
 func TestConfigSerialize(t *testing.T) {
@@ -363,6 +383,14 @@ func TestConfigParseColorSpace(t *testing.T) {
 		if actual != expected {
 			t.Errorf("Expected to parse %q from string, but got %q", expected, actual)
 		}
+	}
+
+	actual, err = CONFIG.ParseColorSpaceFromString("bad")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if actual != "" {
+		t.Errorf("expected an empty string; got %q", actual)
 	}
 }
 

--- a/processor.cpp
+++ b/processor.cpp
@@ -27,10 +27,11 @@ extern "C" {
 
     ProcessorId Processor_Create() {
         OCIO::ProcessorRcPtr ptr;
-        BEGIN_CATCH_ERR
-        ptr = OCIO::Processor::Create();
-        END_CATCH_ERR
-        return NEW_HANDLE_CONTEXT(ocigo::g_Processor_map.add(ptr));
+        ProcessorId p = NEW_HANDLE_CONTEXT();
+        BEGIN_CATCH_CTX_ERR(p)
+        p->handle = ocigo::g_Processor_map.add(OCIO::Processor::Create());
+        END_CATCH_CTX_ERR(p)
+        return p;
     }
 
     bool Processor_isNoOp(ProcessorId p) {

--- a/processor.go
+++ b/processor.go
@@ -40,11 +40,11 @@ func NewProcessor() *Processor {
 	return newProcessor(C.Processor_Create())
 }
 
-func (p *Processor) lastError() error {
+func (p *Processor) lastError(errno ...error) error {
 	if p == nil {
 		return nil
 	}
-	err := getLastError(p.ptr)
+	err := getLastError(p.ptr, errno...)
 	runtime.KeepAlive(p)
 	return err
 }
@@ -78,16 +78,16 @@ func (p *Processor) Metadata() *ProcessorMetadata {
 
 // Apply to an image.
 func (p *Processor) Apply(i ImageDescriptor) error {
-	C.Processor_apply(p.ptr, unsafe.Pointer(i.imageDescPtr()))
-	err := p.lastError()
+	_, err := C.Processor_apply(p.ptr, unsafe.Pointer(i.imageDescPtr()))
+	err = p.lastError(err)
 	runtime.KeepAlive(p)
 	runtime.KeepAlive(i)
 	return err
 }
 
 func (p *Processor) CpuCacheID() (string, error) {
-	id := C.Processor_getCpuCacheID(p.ptr)
-	if err := p.lastError(); err != nil {
+	id, err := C.Processor_getCpuCacheID(p.ptr)
+	if err = p.lastError(err); err != nil {
 		return "", err
 	}
 	runtime.KeepAlive(p)


### PR DESCRIPTION
This merge request fixes issues with error handling that leads to misinterpreting the error condition.  A cheaper "has error" bool has been added to the context and to rely on that first, with the errno as a fallback if an error message isnt available. Also now clearing errno at the end of a successful OCIO call so as not to accidentally trip the error detection.